### PR TITLE
reverting back to hash history mode in vue

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -44,9 +44,7 @@ const routes = [
 ]
 
 const router = createRouter({
-  // history: createWebHashHistory(),
-  // routes: [{ path: '/:pathMatch(.*)', component: NotFoundComponent }],
-  history: createWebHistory(),
+  history: createWebHashHistory(),
   routes
 })
 


### PR DESCRIPTION
#### What does this PR do?
Reverts the Vue router back to hash mode
#### Description of Task to be completed?
I have decided to revert back to hash mode , due to the hacks that are made for it to work
#### How should this be manually tested?
Just navigating to any route it should be able to load
#### Any background context you want to provide?
Normally the hash or pound on the URL is bad for SEO but since is a simplistic app and there is no
need for the hacks trying to configure it to work without the pound on the url.
#### What are the relevant pivotal tracker stories?
No applicable
#### Screenshots (if appropriate)
Not applicable at this point.
#### Questions: