### PR TITLE
adding action prop that was left out in the earlier build

### DIFF
--- a/src/views/Update.vue
+++ b/src/views/Update.vue
@@ -35,6 +35,7 @@ export default {
     return {
       header:"Enter new password",
       submit_text:"Update password",
+      action:null,
       type:null,
       message:null,
       show:false,


### PR DESCRIPTION
#### What does the PR do ?
It adds an action prop
#### Description of the task completed 
I had not defined an action prop for the update password view and hence it was giving errors so I had to add it.